### PR TITLE
Add poller for new messages

### DIFF
--- a/.nais/inbound-message-service-dev.yaml
+++ b/.nais/inbound-message-service-dev.yaml
@@ -61,6 +61,9 @@ spec:
         mountPath: /secret/serviceuser
   accessPolicy:
     outbound:
+      rules:
+        - application: edi-adapter
+          cluster: dev-gcp
     inbound:
       rules:
         - application: azure-token-generator

--- a/README.md
+++ b/README.md
@@ -4,5 +4,33 @@ Application responsible for processing incoming messages to NAV
 
 Overview:
 - Poll for new messages
-- Send `apprec` for message(s)
-- Update message(s) as `read`
+
+## Local development
+
+Running the application locally:
+1. Replace the usage of `ediAdapterClient` with a fake one.
+   See [Replacing ediAdapterClient with a fake](#Replacing-ediAdapterClient-with-a-fake) for more details.
+2. Run the application (typically by running the `App` class in your IDE).
+
+### Configuration
+
+Relevant configuration for adjusting the frequency of scheduler and how many messages to fetch.
+
+| Property          | Description                                                 | Type |
+|-------------------|-------------------------------------------------------------|------|
+| herId             | The receiver herId to fetch messages for (NAV)              | Int  |
+| fetchLimit        | Number of messages to fetch. Number between 1 and 100       | Int  |
+| batchSize         | Number of messages to process per batch                     | Int  |
+| scheduleInterval  | How often scheduler should poll for new messages in minutes | Int  |
+
+### Replacing ediAdapterClient with a fake
+
+To run this locally (meaning without actually sending any HTTP requests) change the following in App.kt:
+```kotlin
+val poller = PollerService(deps.ediAdapterClient)
+```
+
+to use `FakeEdiAdapterClient` instead:
+```kotlin
+val poller = PollerService(FakeEdiAdapterClient())
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_21
         freeCompilerArgs = listOf(
+            "-opt-in=kotlin.time.ExperimentalTime",
             "-opt-in=kotlin.uuid.ExperimentalUuidApi,arrow.fx.coroutines.await.ExperimentalAwaitAllApi"
         )
     }
@@ -48,6 +49,7 @@ dependencies {
     implementation(libs.arrow.suspendapp.ktor)
     implementation(libs.bundles.logging)
     implementation(libs.bundles.prometheus)
+    implementation(libs.bundles.opentelemetry)
     implementation(libs.hoplite.core)
     implementation(libs.hoplite.hocon)
     implementation(libs.jwt)
@@ -64,6 +66,7 @@ dependencies {
     implementation(libs.ktor.server.netty)
     implementation(libs.kotlin.logging)
     implementation(libs.token.validation.ktor.v3)
+    implementation(libs.edi.adapter.client)
     testImplementation(testLibs.bundles.kotest)
     testImplementation(testLibs.kotest.assertions.arrow)
     testImplementation(testLibs.kotest.extensions.jvm)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,9 @@ dependencyResolutionManagement {
             version("prometheus", "1.12.4")
             version("logback", "1.4.11")
             version("logstash", "7.4")
+            version("opentelemetry-mdc", "2.24.0-alpha")
+            version("opentelemetry-extension-kotlin", "1.58.0")
+            version("edi-adapter-client", "0.0.5")
 
             library("arrow-core", "io.arrow-kt", "arrow-core").versionRef("arrow")
             library("arrow-functions", "io.arrow-kt", "arrow-functions").versionRef("arrow")
@@ -58,8 +61,14 @@ dependencyResolutionManagement {
             library("ktor-server-auth-jvm", "io.ktor", "ktor-server-auth-jvm").versionRef("ktor")
             library("token-validation-ktor-v3", "no.nav.security", "token-validation-ktor-v3").versionRef("token-validation-ktor")
 
+            library("opentelemetry-logback-mdc", "io.opentelemetry.instrumentation", "opentelemetry-logback-mdc-1.0").versionRef("opentelemetry-mdc")
+            library("opentelemetry-extension-kotlin", "io.opentelemetry", "opentelemetry-extension-kotlin").versionRef("opentelemetry-extension-kotlin")
+
+            library("edi-adapter-client", "no.nav.helsemelding", "edi-adapter-client").versionRef("edi-adapter-client")
+
             bundle("prometheus", listOf("ktor-server-metrics-micrometer", "micrometer-registry-prometheus"))
             bundle("logging", listOf("logback-classic", "logback-logstash"))
+            bundle("opentelemetry", listOf("opentelemetry-logback-mdc", "opentelemetry-extension-kotlin"))
         }
 
         create("testLibs") {

--- a/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
@@ -4,6 +4,7 @@ import arrow.continuations.SuspendApp
 import arrow.continuations.ktor.server
 import arrow.core.raise.result
 import arrow.fx.coroutines.resourceScope
+import arrow.resilience.Schedule
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
@@ -12,6 +13,7 @@ import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.awaitCancellation
 import no.nav.helsemelding.inbound.plugin.configureMetrics
 import no.nav.helsemelding.inbound.plugin.configureRoutes
+import no.nav.helsemelding.inbound.service.PollerService
 
 private val log = KotlinLogging.logger {}
 
@@ -27,6 +29,10 @@ fun main() = SuspendApp {
                 module = inboundModule(deps.meterRegistry)
             )
 
+            val poller = PollerService(deps.ediAdapterClient)
+
+            scheduleProcessMessages(poller)
+
             awaitCancellation()
         }
     }
@@ -41,5 +47,10 @@ internal fun inboundModule(
         configureRoutes(meterRegistry)
     }
 }
+
+private suspend fun scheduleProcessMessages(processor: PollerService): Long =
+    Schedule
+        .spaced<Unit>(config().poller.scheduleInterval)
+        .repeat { processor.pollMessages() }
 
 private fun logError(t: Throwable) = log.error { "Shutdown inbound-message-service due to: ${t.stackTraceToString()}" }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/Dependencies.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/Dependencies.kt
@@ -6,11 +6,16 @@ import arrow.fx.coroutines.await.awaitAll
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.prometheus.PrometheusConfig.DEFAULT
 import io.micrometer.prometheus.PrometheusMeterRegistry
+import no.nav.helsemelding.ediadapter.client.EdiAdapterClient
+import no.nav.helsemelding.ediadapter.client.HttpEdiAdapterClient
+import no.nav.helsemelding.ediadapter.client.scopedAuthHttpClient
+import no.nav.helsemelding.inbound.config.EdiAdapter
 
 private val log = KotlinLogging.logger {}
 
 data class Dependencies(
-    val meterRegistry: PrometheusMeterRegistry
+    val meterRegistry: PrometheusMeterRegistry,
+    val ediAdapterClient: EdiAdapterClient
 )
 
 internal suspend fun ResourceScope.metricsRegistry(): PrometheusMeterRegistry =
@@ -18,10 +23,19 @@ internal suspend fun ResourceScope.metricsRegistry(): PrometheusMeterRegistry =
         p.close().also { log.info { "Closed prometheus registry" } }
     }
 
+internal suspend fun ResourceScope.ediAdapterClient(ediAdapter: EdiAdapter): EdiAdapterClient =
+    install({ HttpEdiAdapterClient(scopedAuthHttpClient(ediAdapter.scope.value)) }) { p, _: ExitCase ->
+        p.close().also { log.info { "Closed edi adapter client" } }
+    }
+
 suspend fun ResourceScope.dependencies(): Dependencies = awaitAll {
+    val config = config()
+
     val metricsRegistry = async { metricsRegistry() }
+    val ediAdapterClient = async { ediAdapterClient(config.ediAdapter) }
 
     Dependencies(
-        metricsRegistry.await()
+        metricsRegistry.await(),
+        ediAdapterClient.await()
     )
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/config/Config.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/config/Config.kt
@@ -3,12 +3,32 @@ package no.nav.helsemelding.inbound.config
 import kotlin.time.Duration
 
 data class Config(
-    val server: Server
-)
+    val server: Server,
+    val ediAdapter: EdiAdapter,
+    val poller: Poller
+) {
+    init {
+        require(poller.fetchLimit in 1..100, { "fetchLimit must be between 1..100" })
+    }
+}
 
 data class Server(
     val port: Port,
     val preWait: Duration
+)
+
+data class EdiAdapter(
+    val scope: Scope
+) {
+    @JvmInline
+    value class Scope(val value: String)
+}
+
+data class Poller(
+    val herId: Int,
+    val fetchLimit: Int,
+    val batchSize: Int,
+    val scheduleInterval: Duration
 )
 
 @JvmInline

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -1,0 +1,92 @@
+package no.nav.helsemelding.inbound.service
+
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.fx.coroutines.parMap
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.opentelemetry.api.GlobalOpenTelemetry
+import kotlinx.coroutines.Dispatchers
+import no.nav.helsemelding.ediadapter.client.EdiAdapterClient
+import no.nav.helsemelding.ediadapter.model.ErrorMessage
+import no.nav.helsemelding.ediadapter.model.GetMessagesRequest
+import no.nav.helsemelding.ediadapter.model.Message
+import no.nav.helsemelding.inbound.config
+import no.nav.helsemelding.inbound.util.withSpan
+
+private val log = KotlinLogging.logger {}
+private val tracer = GlobalOpenTelemetry.getTracer("PollerService")
+
+class PollerService(
+    private val ediAdapterClient: EdiAdapterClient
+) {
+    private val pollerConfig = config().poller
+
+    suspend fun pollMessages() {
+        log.info { "=== Poll cycle start ===" }
+        val cycleStart = System.currentTimeMillis()
+
+        fetchMessages(pollerConfig.fetchLimit, pollerConfig.herId)
+            .withLogging()
+            .chunked(pollerConfig.batchSize)
+            .forEach { processBatch(it) }
+
+        log.info { "=== Poll cycle end: ${System.currentTimeMillis() - cycleStart}ms ===" }
+    }
+
+    private suspend fun fetchMessages(messagesToFetch: Int, herId: Int): List<Message> {
+        val getMessagesRequest = GetMessagesRequest(
+            receiverHerIds = listOf(herId),
+            includeMetadata = true,
+            messagesToFetch = messagesToFetch
+        )
+
+        return when (val messages = ediAdapterClient.getMessages(getMessagesRequest)) {
+            is Right<List<Message>> ->
+                messages.value
+                    .filter { it.id != null }
+                    .filter { it.receiverHerId != null }
+                    .filter { it.isAppRec == false }
+
+            is Left<ErrorMessage> -> {
+                log.error { "Failed to get messages for herId: $herId. Error: ${messages.value}" }
+                emptyList()
+            }
+        }
+    }
+
+    private suspend fun processBatch(batch: List<Message>) {
+        val summary = batch.batchSummary()
+        log.info { "Processing ($summary)" }
+
+        logBatchDuration(summary) {
+            batch.parMap(Dispatchers.IO) { processMessage(it) }
+        }
+    }
+
+    internal suspend fun processMessage(message: Message): Boolean {
+        return tracer.withSpan("Process incoming message") {
+            log.info { "Processing message: ${message.id}" }
+            true
+        }
+    }
+
+    private fun List<Message>.withLogging(): List<Message> = also {
+        log.info { "Fetched messages size=$size" }
+    }
+
+    private fun List<Message>.batchSummary(): String =
+        when (size) {
+            0 -> "batchSize=0"
+            1 -> "batchSize=1 id=${first().id}"
+            else -> "batchSize=$size first=${first().id} last=${last().id}"
+        }
+
+    private inline fun <T> logBatchDuration(summary: String, block: () -> T): T {
+        val start = System.currentTimeMillis()
+        return try {
+            block()
+        } finally {
+            log.info { "Batch completed ($summary took ${System.currentTimeMillis() - start}ms)" }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helsemelding/inbound/util/FakeEdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/util/FakeEdiAdapterClient.kt
@@ -15,7 +15,7 @@ import no.nav.helsemelding.ediadapter.model.PostMessageRequest
 import no.nav.helsemelding.ediadapter.model.StatusInfo
 import kotlin.uuid.Uuid
 
-const val FAGSYSTEM_HERID = 8142519
+const val FAGSYSTEM_HER_ID = 8142519
 
 class FakeEdiAdapterClient : EdiAdapterClient {
     private val messageById = mutableMapOf<Uuid, Either<ErrorMessage, Message>>()
@@ -67,7 +67,7 @@ class FakeEdiAdapterClient : EdiAdapterClient {
         val messages = List(getMessagesRequest.messagesToFetch) {
             Message(
                 id = Uuid.random(),
-                receiverHerId = FAGSYSTEM_HERID,
+                receiverHerId = FAGSYSTEM_HER_ID,
                 isAppRec = false
             )
         }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/util/FakeEdiAdapterClient.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/util/FakeEdiAdapterClient.kt
@@ -1,0 +1,82 @@
+package no.nav.helsemelding.inbound.util
+
+import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import no.nav.helsemelding.ediadapter.client.EdiAdapterClient
+import no.nav.helsemelding.ediadapter.model.ApprecInfo
+import no.nav.helsemelding.ediadapter.model.ErrorMessage
+import no.nav.helsemelding.ediadapter.model.GetBusinessDocumentResponse
+import no.nav.helsemelding.ediadapter.model.GetMessagesRequest
+import no.nav.helsemelding.ediadapter.model.Message
+import no.nav.helsemelding.ediadapter.model.Metadata
+import no.nav.helsemelding.ediadapter.model.PostAppRecRequest
+import no.nav.helsemelding.ediadapter.model.PostMessageRequest
+import no.nav.helsemelding.ediadapter.model.StatusInfo
+import kotlin.uuid.Uuid
+
+const val FAGSYSTEM_HERID = 8142519
+
+class FakeEdiAdapterClient : EdiAdapterClient {
+    private val messageById = mutableMapOf<Uuid, Either<ErrorMessage, Message>>()
+    private val postApprecById = mutableMapOf<Uuid, Either<ErrorMessage, Metadata>>()
+    private val markAsReadById = mutableMapOf<Uuid, Either<ErrorMessage, Boolean>>()
+
+    val errorMessage404 = ErrorMessage(
+        error = "Not Found",
+        errorCode = 1000,
+        requestId = Uuid.random().toString()
+    )
+
+    fun givenMarkAsRead(id: Uuid, isMarked: Either<ErrorMessage, Boolean>) {
+        markAsReadById[id] = isMarked
+    }
+
+    fun givenPostApprec(
+        id: Uuid,
+        apprecResponse: Either<ErrorMessage, Metadata>
+    ) {
+        postApprecById[id] = apprecResponse
+    }
+
+    override suspend fun getMessageStatus(id: Uuid): Either<ErrorMessage, List<StatusInfo>> = Right(emptyList())
+
+    override suspend fun getMessage(id: Uuid): Either<ErrorMessage, Message> = Left(errorMessage404)
+
+    override suspend fun getBusinessDocument(id: Uuid): Either<ErrorMessage, GetBusinessDocumentResponse> =
+        Left(errorMessage404)
+
+    override suspend fun postApprec(
+        id: Uuid,
+        apprecSenderHerId: Int,
+        postAppRecRequest: PostAppRecRequest
+    ): Either<ErrorMessage, Metadata> {
+        return postApprecById[id] ?: when (messageById[id]) {
+            is Right -> Right(Metadata(Uuid.random(), ""))
+            else -> Left(errorMessage404)
+        }
+    }
+
+    override suspend fun markMessageAsRead(id: Uuid, herId: Int): Either<ErrorMessage, Boolean> =
+        markAsReadById[id] ?: Right(true)
+
+    override suspend fun getApprecInfo(id: Uuid): Either<ErrorMessage, List<ApprecInfo>> =
+        Right(emptyList())
+
+    override suspend fun getMessages(getMessagesRequest: GetMessagesRequest): Either<ErrorMessage, List<Message>> {
+        val messages = List(getMessagesRequest.messagesToFetch) {
+            Message(
+                id = Uuid.random(),
+                receiverHerId = FAGSYSTEM_HERID,
+                isAppRec = false
+            )
+        }
+        messages.forEach { messageById[it.id!!] = Right(it) }
+        return Right(messages)
+    }
+
+    override suspend fun postMessage(postMessagesRequest: PostMessageRequest): Either<ErrorMessage, Metadata> =
+        Left(errorMessage404)
+
+    override fun close() {}
+}

--- a/src/main/kotlin/no/nav/helsemelding/inbound/util/ResourceUtil.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/util/ResourceUtil.kt
@@ -1,0 +1,27 @@
+package no.nav.helsemelding.inbound.util
+
+import arrow.fx.coroutines.ExitCase
+import arrow.fx.coroutines.ResourceScope
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlin.coroutines.CoroutineContext
+
+private val log = KotlinLogging.logger {}
+
+/** Installs a coroutine scope as a resource **/
+suspend fun ResourceScope.coroutineScope(context: CoroutineContext): CoroutineScope {
+    val currentContext = currentCoroutineContext()
+    val job = currentContext[Job]?.let { Job(it) } ?: Job()
+    return install({ CoroutineScope(context + currentContext + job) }) { _, exitCase ->
+        log.info { "Exit case: $exitCase" }
+        when (exitCase) {
+            ExitCase.Completed -> job.cancel()
+            is ExitCase.Cancelled -> job.cancel(exitCase.exception)
+            is ExitCase.Failure -> job.cancel("Resource failed, so cancelling associated scope", exitCase.failure)
+        }
+        job.join()
+    }
+}

--- a/src/main/kotlin/no/nav/helsemelding/inbound/util/Tracing.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/util/Tracing.kt
@@ -1,0 +1,21 @@
+package no.nav.helsemelding.inbound.util
+
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import kotlinx.coroutines.withContext
+
+suspend inline fun <T> Tracer.withSpan(
+    spanName: String,
+    crossinline block: suspend () -> T
+): T {
+    val span = spanBuilder(spanName).startSpan()
+    return try {
+        val otelContext = Context.current().with(span)
+        withContext(otelContext.asContextElement()) {
+            block()
+        }
+    } finally {
+        span.end()
+    }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,7 +9,7 @@ ediAdapter {
 }
 
 poller {
-  herId = "${POLLER_HERID:-8142519}"
+  herId = "${POLLER_HER_ID:-8142519}"
   fetchLimit = "${POLLER_FETCH_LIMIT:-10}"
   batchSize = "${POLLER_BATCH_SIZE:-5}"
   scheduleInterval = "${POLLER_SCHEDULE_INTERVAL:-2}m"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,3 +3,14 @@ server {
   // time before shutdown is initiated
   preWait = "5s"
 }
+
+ediAdapter {
+  scope = "api://dev-gcp.helsemelding.edi-adapter/.default"
+}
+
+poller {
+  herId = "${POLLER_HERID:-8142519}"
+  fetchLimit = "${POLLER_FETCH_LIMIT:-10}"
+  batchSize = "${POLLER_BATCH_SIZE:-5}"
+  scheduleInterval = "${POLLER_SCHEDULE_INTERVAL:-2}m"
+}


### PR DESCRIPTION
Legger til polling av nye meldinger uten å gjøre noe med dem. I tillegg er følgende implementert:
- `HerId` i config
- Batching
- Tracing

Issue: https://github.com/navikt/helsemelding-inbound-message-service/issues/1

TODO:
- [x] Gi tilgang til `edi-adapter` (separat [PR](https://github.com/navikt/helsemelding-edi-adapter/pull/58))
- [x] Test i dev