### PR TITLE
Add processing of apprec

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -12,6 +12,7 @@ import no.nav.helsemelding.ediadapter.model.GetMessagesRequest
 import no.nav.helsemelding.ediadapter.model.Message
 import no.nav.helsemelding.inbound.config
 import no.nav.helsemelding.inbound.util.withSpan
+import kotlin.uuid.Uuid
 
 private val log = KotlinLogging.logger {}
 private val tracer = GlobalOpenTelemetry.getTracer("PollerService")
@@ -45,7 +46,6 @@ class PollerService(
                 messages.value
                     .filter { it.id != null }
                     .filter { it.receiverHerId != null }
-                    .filter { it.isAppRec == false }
 
             is Left<ErrorMessage> -> {
                 log.error { "Failed to get messages for herId: $herId. Error: ${messages.value}" }
@@ -66,7 +66,27 @@ class PollerService(
     internal suspend fun processMessage(message: Message): Boolean {
         return tracer.withSpan("Process incoming message") {
             log.info { "Processing message: ${message.id}" }
-            true
+            when (message.isAppRec) {
+                true -> {
+                    log.info { "Processing apprec: ${message.id}" }
+                    markMessageAsRead(message.id!!, message.receiverHerId!!)
+                }
+                else -> false
+            }
+        }
+    }
+
+    private suspend fun markMessageAsRead(messageId: Uuid, herId: Int): Boolean {
+        return when (val either = ediAdapterClient.markMessageAsRead(messageId, herId)) {
+            is Right<Boolean> -> {
+                log.info { "Successfully marked message: $messageId as read." }
+                either.value
+            }
+
+            is Left<ErrorMessage> -> {
+                log.error { "Failed to mark message: $messageId as read. Error: ${either.value}" }
+                false
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -69,6 +69,7 @@ class PollerService(
             when (message.isAppRec) {
                 true -> {
                     log.info { "Processing apprec: ${message.id}" }
+                    // TODO: Can be removed when outbound-message-service handles apprec
                     markMessageAsRead(message.id!!, message.receiverHerId!!)
                 }
                 else -> false

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
@@ -1,0 +1,73 @@
+package no.nav.helsemelding.inbound.service
+
+import arrow.core.Either
+import arrow.core.Either.Right
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.data.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import no.nav.helsemelding.ediadapter.model.ErrorMessage
+import no.nav.helsemelding.ediadapter.model.Message
+import no.nav.helsemelding.inbound.util.FAGSYSTEM_HER_ID
+import no.nav.helsemelding.inbound.util.FakeEdiAdapterClient
+import kotlin.uuid.Uuid
+
+class PollerServiceSpec : StringSpec(
+    {
+        "message should be processed if it is an apprec" {
+            val uuid = Uuid.random()
+            val ediAdapterClient = FakeEdiAdapterClient()
+            ediAdapterClient.givenMarkAsRead(uuid, Right(true))
+            val pollerService = PollerService(ediAdapterClient)
+
+            val message = Message(
+                id = uuid,
+                isAppRec = true,
+                receiverHerId = FAGSYSTEM_HER_ID
+            )
+
+            pollerService.processMessage(message) shouldBe true
+        }
+
+        "message should not be processed if it's not an apprec" {
+            forAll(
+                row(null),
+                row(false)
+            ) { isApprec ->
+                val uuid = Uuid.random()
+                val ediAdapterClient = FakeEdiAdapterClient()
+                ediAdapterClient.givenMarkAsRead(uuid, Right(true))
+                val pollerService = PollerService(ediAdapterClient)
+
+                val message = Message(
+                    id = uuid,
+                    isAppRec = isApprec,
+                    receiverHerId = FAGSYSTEM_HER_ID
+                )
+
+                pollerService.processMessage(message) shouldBe false
+            }
+        }
+
+        "message should not be processed if ediAdapterClient returns error" {
+            val uuid = Uuid.random()
+            val ediAdapterClient = FakeEdiAdapterClient()
+
+            val errorMessage500 = ErrorMessage(
+                error = "Internal Server Error",
+                errorCode = 1000,
+                requestId = Uuid.random().toString()
+            )
+            ediAdapterClient.givenMarkAsRead(uuid, Either.Left(errorMessage500))
+            val pollerService = PollerService(ediAdapterClient)
+
+            val message = Message(
+                id = uuid,
+                isAppRec = true,
+                receiverHerId = FAGSYSTEM_HER_ID
+            )
+
+            pollerService.processMessage(message) shouldBe false
+        }
+    }
+)


### PR DESCRIPTION
Lagt til midlertidig kode for å håndtere apprec som genereres av [epj-simulator](https://github.com/navikt/helsemelding-epj-simulator). Dette ble forsøkt løst i en tidligere [PR](https://github.com/navikt/helsemelding-epj-simulator/pull/4/changes#diff-501fac2a7ca584cf59afa9ab18a716c3e8f230948fa4ac2d9341ff0fbcf2d909R66), men det er tydeligvis for tidlig å sette apprec som lest. 

Dette er primært for å sørge for at de generte apprecene blir tatt unna. Per nå så skal det ikke være noen vanlige meldinger som sendes til denne mottakeren (`8142519`), mao. så skal ikke dette stoppe opp ettersom det ikke finnes annet enn apprecs.

- [x] Teste i dev