### PR TITLE
#12 metrikker for innkommende meldingsflyt

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
@@ -11,6 +11,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.utils.io.CancellationException
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.awaitCancellation
+import no.nav.helsemelding.inbound.metrics.CustomMetrics
 import no.nav.helsemelding.inbound.plugin.configureMetrics
 import no.nav.helsemelding.inbound.plugin.configureRoutes
 import no.nav.helsemelding.inbound.publisher.DialogMessagePublisher
@@ -22,6 +23,7 @@ fun main() = SuspendApp {
     result {
         resourceScope {
             val deps = dependencies()
+            val metrics = CustomMetrics(deps.meterRegistry)
 
             server(
                 Netty,
@@ -31,7 +33,11 @@ fun main() = SuspendApp {
             )
 
             val dialogMessagePublisher = DialogMessagePublisher(deps.kafkaPublisher)
-            val poller = PollerService(deps.ediAdapterClient, dialogMessagePublisher)
+            val poller = PollerService(
+                deps.ediAdapterClient,
+                dialogMessagePublisher,
+                metrics
+            )
 
             scheduleProcessMessages(poller)
 

--- a/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
@@ -7,21 +7,22 @@ import io.micrometer.core.instrument.MeterRegistry
 private val log = KotlinLogging.logger {}
 
 interface Metrics {
-    fun registerIncomingMessageReceived()
+    fun registerIncomingMessageReceived(isApprec: Boolean = false)
 }
 
 class CustomMetrics(val registry: MeterRegistry) : Metrics {
 
-    override fun registerIncomingMessageReceived() {
+    override fun registerIncomingMessageReceived(isApprec: Boolean) {
         Counter.builder("helsemelding_incoming_messages_received")
             .description("Number of incoming messages received from NHN")
+            .tag("isApprec", isApprec.toString())
             .register(registry)
             .increment()
     }
 }
 
 class FakeMetrics() : Metrics {
-    override fun registerIncomingMessageReceived() {
+    override fun registerIncomingMessageReceived(isApprec: Boolean) {
         log.info { "helsemelding_incoming_messages_received metric is registered" }
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
@@ -3,12 +3,15 @@ package no.nav.helsemelding.inbound.metrics
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import java.util.concurrent.TimeUnit
 
 private val log = KotlinLogging.logger {}
 
 interface Metrics {
     fun registerIncomingMessageReceived(isApprec: Boolean = false)
     fun registerIncomingMessageFailed(errorType: ErrorTypeTag)
+    fun registerIncomingMessageProcessingDuration(durationNanos: Long)
 }
 
 class CustomMetrics(val registry: MeterRegistry) : Metrics {
@@ -28,6 +31,14 @@ class CustomMetrics(val registry: MeterRegistry) : Metrics {
             .register(registry)
             .increment()
     }
+
+    override fun registerIncomingMessageProcessingDuration(durationNanos: Long) {
+        Timer.builder("helsemelding_incoming_message_processing_duration")
+            .description("Time spent processing an incoming message")
+            .publishPercentileHistogram()
+            .register(registry)
+            .record(durationNanos, TimeUnit.NANOSECONDS)
+    }
 }
 
 class FakeMetrics() : Metrics {
@@ -37,5 +48,9 @@ class FakeMetrics() : Metrics {
 
     override fun registerIncomingMessageFailed(errorType: ErrorTypeTag) {
         log.info { "helsemelding_incoming_messages_failed metric is registered with error_type: ${errorType.value}" }
+    }
+
+    override fun registerIncomingMessageProcessingDuration(durationNanos: Long) {
+        log.info { "helsemelding_incoming_message_processing_duration metric is registered with duration: $durationNanos ns" }
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
@@ -1,0 +1,27 @@
+package no.nav.helsemelding.inbound.metrics
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+
+private val log = KotlinLogging.logger {}
+
+interface Metrics {
+    fun registerIncomingMessageReceived()
+}
+
+class CustomMetrics(val registry: MeterRegistry) : Metrics {
+
+    override fun registerIncomingMessageReceived() {
+        Counter.builder("helsemelding_incoming_messages_received")
+            .description("Number of incoming messages received from NHN")
+            .register(registry)
+            .increment()
+    }
+}
+
+class FakeMetrics() : Metrics {
+    override fun registerIncomingMessageReceived() {
+        log.info { "helsemelding_incoming_messages_received metric is registered" }
+    }
+}

--- a/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/metrics/CustomMetrics.kt
@@ -8,6 +8,7 @@ private val log = KotlinLogging.logger {}
 
 interface Metrics {
     fun registerIncomingMessageReceived(isApprec: Boolean = false)
+    fun registerIncomingMessageFailed(errorType: ErrorTypeTag)
 }
 
 class CustomMetrics(val registry: MeterRegistry) : Metrics {
@@ -15,7 +16,15 @@ class CustomMetrics(val registry: MeterRegistry) : Metrics {
     override fun registerIncomingMessageReceived(isApprec: Boolean) {
         Counter.builder("helsemelding_incoming_messages_received")
             .description("Number of incoming messages received from NHN")
-            .tag("isApprec", isApprec.toString())
+            .tag("is_apprec", isApprec.toString())
+            .register(registry)
+            .increment()
+    }
+
+    override fun registerIncomingMessageFailed(errorType: ErrorTypeTag) {
+        Counter.builder("helsemelding_incoming_messages_failed")
+            .description("Number of incoming messages that failed to be processed")
+            .tag("error_type", errorType.value)
             .register(registry)
             .increment()
     }
@@ -23,6 +32,10 @@ class CustomMetrics(val registry: MeterRegistry) : Metrics {
 
 class FakeMetrics() : Metrics {
     override fun registerIncomingMessageReceived(isApprec: Boolean) {
-        log.info { "helsemelding_incoming_messages_received metric is registered" }
+        log.info { "helsemelding_incoming_messages_received metric is registered with is_apprec: $isApprec" }
+    }
+
+    override fun registerIncomingMessageFailed(errorType: ErrorTypeTag) {
+        log.info { "helsemelding_incoming_messages_failed metric is registered with error_type: ${errorType.value}" }
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/metrics/ErrorTypeTag.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/metrics/ErrorTypeTag.kt
@@ -1,0 +1,8 @@
+package no.nav.helsemelding.inbound.metrics
+
+enum class ErrorTypeTag(val value: String) {
+    RETRIEVING_BUSINESS_DOCUMENT_FAILED("retrieving_business_document_failed"),
+    PUBLISHING_TO_KAFKA_FAILED("publishing_to_kafka_failed"),
+    MARKING_MESSAGE_AS_READ_FAILED("marking_message_as_read_failed"),
+    SENDING_APPREC_FAILED("sending_apprec_failed")
+}

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -68,11 +68,7 @@ class PollerService(
         log.info { "Processing ($summary)" }
 
         logBatchDuration(summary) {
-            batch
-                .parMap(Dispatchers.IO) {
-                    metrics.registerIncomingMessageReceived()
-                    processMessage(it)
-                }
+            batch.parMap(Dispatchers.IO) { processMessage(it) }
         }
     }
 
@@ -92,11 +88,15 @@ class PollerService(
     private suspend fun processAppRec(messageId: Uuid, receiverHerId: Int): Boolean {
         // TODO: Can be removed when outbound-message-service handles apprec
         log.info { "Processing apprec: $messageId" }
+        metrics.registerIncomingMessageReceived(true)
+
         return markMessageAsRead(messageId, receiverHerId)
     }
 
     private suspend fun processIncomingMessage(messageId: Uuid, receiverHerId: Int): Boolean {
         log.info { "Processing incoming message: $messageId" }
+        metrics.registerIncomingMessageReceived()
+
         val businessDocument = getBusinessDocument(messageId) ?: return false
 
         val isPublishingSuccessful = publishMessageToKafka(messageId, businessDocument)

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -18,6 +18,7 @@ import no.nav.helsemelding.inbound.config
 import no.nav.helsemelding.inbound.metrics.ErrorTypeTag
 import no.nav.helsemelding.inbound.metrics.Metrics
 import no.nav.helsemelding.inbound.publisher.MessagePublisher
+import no.nav.helsemelding.inbound.util.registerDuration
 import no.nav.helsemelding.inbound.util.withSpan
 import java.util.Base64
 import kotlin.uuid.Uuid
@@ -81,7 +82,9 @@ class PollerService(
             log.info { "Processing message: $messageId" }
             when (message.isAppRec) {
                 true -> processAppRec(messageId, receiverHerId)
-                else -> processIncomingMessage(messageId, receiverHerId)
+                else -> registerDuration(metrics::registerIncomingMessageProcessingDuration) {
+                    processIncomingMessage(messageId, receiverHerId)
+                }
             }
         }
     }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -15,6 +15,7 @@ import no.nav.helsemelding.ediadapter.model.Message
 import no.nav.helsemelding.ediadapter.model.Metadata
 import no.nav.helsemelding.ediadapter.model.PostAppRecRequest
 import no.nav.helsemelding.inbound.config
+import no.nav.helsemelding.inbound.metrics.ErrorTypeTag
 import no.nav.helsemelding.inbound.metrics.Metrics
 import no.nav.helsemelding.inbound.publisher.MessagePublisher
 import no.nav.helsemelding.inbound.util.withSpan
@@ -122,6 +123,7 @@ class PollerService(
             }
             is Left<ErrorMessage> -> {
                 log.error { "Failed to send apprec for message: $messageId. Error: ${response.value}" }
+                metrics.registerIncomingMessageFailed(ErrorTypeTag.SENDING_APPREC_FAILED)
                 false
             }
         }
@@ -136,6 +138,7 @@ class PollerService(
 
             is Left<ErrorMessage> -> {
                 log.error { "Failed to mark message: $messageId as read. Error: ${either.value}" }
+                metrics.registerIncomingMessageFailed(ErrorTypeTag.MARKING_MESSAGE_AS_READ_FAILED)
                 false
             }
         }
@@ -149,6 +152,7 @@ class PollerService(
             }
             is Left<ErrorMessage> -> {
                 log.error { "Failed to retrieve business document for message: $messageId: ${response.value.error} Stack trace: ${response.value.stackTrace}" }
+                metrics.registerIncomingMessageFailed(ErrorTypeTag.RETRIEVING_BUSINESS_DOCUMENT_FAILED)
                 null
             }
         }
@@ -165,6 +169,7 @@ class PollerService(
             }
             .getOrElse { t ->
                 log.error(t) { "Failed to publish message to Kafka: $key" }
+                metrics.registerIncomingMessageFailed(ErrorTypeTag.PUBLISHING_TO_KAFKA_FAILED)
                 false
             }
     }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -133,22 +133,7 @@ class PollerService(
     }
 
     private suspend fun markMessageAsRead(messageId: Uuid, herId: Int): Boolean {
-        var either = ediAdapterClient.markMessageAsRead(messageId, herId)
-
-        // TODO: FOR TESTING PURPOSE ONLY. REMOVE BEFORE MERGE
-        if (System.getenv("NAIS_CLUSTER_NAME") == "dev-gcp") {
-            if ((0..9).random() == 0) {
-                either = Left(
-                    ErrorMessage(
-                        error = "Simulated random failure",
-                        errorCode = 500,
-                        requestId = Uuid.random().toString()
-                    )
-                )
-            }
-        }
-
-        return when (either) {
+        return when (val either = ediAdapterClient.markMessageAsRead(messageId, herId)) {
             is Right<Boolean> -> {
                 log.info { "Successfully marked message: $messageId as read." }
                 either.value
@@ -163,22 +148,7 @@ class PollerService(
     }
 
     private suspend fun getBusinessDocument(messageId: Uuid): String? {
-        var response = ediAdapterClient.getBusinessDocument(messageId)
-
-        // TODO: FOR TESTING PURPOSE ONLY. REMOVE BEFORE MERGE
-        if (System.getenv("NAIS_CLUSTER_NAME") == "dev-gcp") {
-            if ((0..9).random() == 0) {
-                response = Left(
-                    ErrorMessage(
-                        error = "Simulated random failure",
-                        errorCode = 500,
-                        requestId = Uuid.random().toString()
-                    )
-                )
-            }
-        }
-
-        return when (response) {
+        return when (val response = ediAdapterClient.getBusinessDocument(messageId)) {
             is Right<GetBusinessDocumentResponse> -> {
                 log.info { "Retrieved business document for message: $messageId" }
                 response.value.businessDocument

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -15,6 +15,7 @@ import no.nav.helsemelding.ediadapter.model.Message
 import no.nav.helsemelding.ediadapter.model.Metadata
 import no.nav.helsemelding.ediadapter.model.PostAppRecRequest
 import no.nav.helsemelding.inbound.config
+import no.nav.helsemelding.inbound.metrics.Metrics
 import no.nav.helsemelding.inbound.publisher.MessagePublisher
 import no.nav.helsemelding.inbound.util.withSpan
 import java.util.Base64
@@ -25,7 +26,8 @@ private val tracer = GlobalOpenTelemetry.getTracer("PollerService")
 
 class PollerService(
     private val ediAdapterClient: EdiAdapterClient,
-    private val messagePublisher: MessagePublisher
+    private val messagePublisher: MessagePublisher,
+    private val metrics: Metrics
 ) {
     private val pollerConfig = config().poller
 
@@ -66,7 +68,11 @@ class PollerService(
         log.info { "Processing ($summary)" }
 
         logBatchDuration(summary) {
-            batch.parMap(Dispatchers.IO) { processMessage(it) }
+            batch
+                .parMap(Dispatchers.IO) {
+                    metrics.registerIncomingMessageReceived()
+                    processMessage(it)
+                }
         }
     }
 

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -130,7 +130,22 @@ class PollerService(
     }
 
     private suspend fun markMessageAsRead(messageId: Uuid, herId: Int): Boolean {
-        return when (val either = ediAdapterClient.markMessageAsRead(messageId, herId)) {
+        var either = ediAdapterClient.markMessageAsRead(messageId, herId)
+
+        // TODO: FOR TESTING PURPOSE ONLY. REMOVE BEFORE MERGE
+        if (System.getenv("NAIS_CLUSTER_NAME") == "dev-gcp") {
+            if ((0..9).random() == 0) {
+                either = Left(
+                    ErrorMessage(
+                        error = "Simulated random failure",
+                        errorCode = 500,
+                        requestId = Uuid.random().toString()
+                    )
+                )
+            }
+        }
+
+        return when (either) {
             is Right<Boolean> -> {
                 log.info { "Successfully marked message: $messageId as read." }
                 either.value
@@ -145,7 +160,22 @@ class PollerService(
     }
 
     private suspend fun getBusinessDocument(messageId: Uuid): String? {
-        return when (val response = ediAdapterClient.getBusinessDocument(messageId)) {
+        var response = ediAdapterClient.getBusinessDocument(messageId)
+
+        // TODO: FOR TESTING PURPOSE ONLY. REMOVE BEFORE MERGE
+        if (System.getenv("NAIS_CLUSTER_NAME") == "dev-gcp") {
+            if ((0..9).random() == 0) {
+                response = Left(
+                    ErrorMessage(
+                        error = "Simulated random failure",
+                        errorCode = 500,
+                        requestId = Uuid.random().toString()
+                    )
+                )
+            }
+        }
+
+        return when (response) {
             is Right<GetBusinessDocumentResponse> -> {
                 log.info { "Retrieved business document for message: $messageId" }
                 response.value.businessDocument

--- a/src/main/kotlin/no/nav/helsemelding/inbound/util/MetricsUtils.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/util/MetricsUtils.kt
@@ -1,0 +1,15 @@
+package no.nav.helsemelding.inbound.util
+
+import kotlin.system.measureNanoTime
+
+suspend fun <T> registerDuration(
+    registratorFunction: (Long) -> Unit,
+    block: suspend () -> T
+): T {
+    var result: T
+    val durationNanos = measureNanoTime {
+        result = block()
+    }
+    registratorFunction(durationNanos)
+    return result
+}

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
@@ -9,6 +9,7 @@ import no.nav.helsemelding.ediadapter.model.GetBusinessDocumentResponse
 import no.nav.helsemelding.ediadapter.model.Message
 import no.nav.helsemelding.ediadapter.model.Metadata
 import no.nav.helsemelding.inbound.FakeMessagePublisher
+import no.nav.helsemelding.inbound.metrics.FakeMetrics
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import java.util.Base64
@@ -25,7 +26,11 @@ class PollerServiceSpec : StringSpec(
         beforeEach {
             ediAdapterClient = FakeEdiAdapterClient()
             publisher = FakeMessagePublisher()
-            pollerService = PollerService(ediAdapterClient, publisher)
+            pollerService = PollerService(
+                ediAdapterClient,
+                publisher,
+                FakeMetrics()
+            )
         }
 
         "Apprec should be processed" {


### PR DESCRIPTION
Metrikker for innkommende meldigsflyt:

- `helsemelding_incoming_messages_received` - antall meldinger mottatt fra NHN. Måles separat for _apprec_-er og vanlige meldinger.
- `helsemelding_incoming_messages_failed `- antall meldinger har blitt mottatt fra NHN men prosessert med feil. Typer feil:
    - `retrieving_business_document_failed` - feil ved henting XML dokument fra NHN.
    - `publishing_to_kafka_failed` - feil ved sending melding til Kafka.
    - `marking_message_as_read_failed` - feil ved markering melding som lest hos NHN.
    - `sending_apprec_failed` - feil ved sending apprec.
- `helsemelding_incoming_message_processing_duration` - tiden brukt på prosessering av en melding (innhenting XML dokument --> sending dokumentet til Kafka --> markering meldingen som lest --> sending apprec)

Oppgave: https://github.com/navikt/helsemelding-inbound-message-service/issues/12