### PR TITLE
#15 Fjerne vedlegg fra meldinger og lagre det separat (Omgang #2)

### DIFF
--- a/.nais/inbound-message-service-dev.yaml
+++ b/.nais/inbound-message-service-dev.yaml
@@ -67,7 +67,7 @@ spec:
         - application: edi-adapter
           cluster: dev-gcp
         - application: attachment-service
-          namespace: dev-gcp
+          cluster: dev-gcp
     inbound:
       rules:
         - application: azure-token-generator

--- a/.nais/inbound-message-service-dev.yaml
+++ b/.nais/inbound-message-service-dev.yaml
@@ -66,6 +66,8 @@ spec:
       rules:
         - application: edi-adapter
           cluster: dev-gcp
+        - application: attachment-service
+          namespace: dev-gcp
     inbound:
       rules:
         - application: azure-token-generator

--- a/README.md
+++ b/README.md
@@ -2,19 +2,23 @@
 
 Application responsible for processing incoming messages to NAV
 
-Overview:
-- Poll for new messages and process them one by one:
-  - If the message is an apprec - mark message as read.
-  - If the message is an incoming message - get business document for this message.
-    - If the business document is retrieved - decode it from Base64 string and send to Kafka.
-      - if the message is successfully sent to Kafka - mark the message as read.
+## Overview
 
-## Local development
+The service polls EDI Adapter for incoming messages for a configured HER-id.
 
-Running the application locally:
-1. Replace the usage of `ediAdapterClient` with a fake one.
-   See [Replacing ediAdapterClient with a fake](#Replacing-ediAdapterClient-with-a-fake) for more details.
-2. Run the application (typically by running the `App` class in your IDE).
+Each message is processed depending on its type:
+
+1. If the message is an `AppRec`, the service marks it as read using EDI Adapter.
+2. If the message is a normal incoming message, the service:
+   - fetches the business document using EDI Adapter.
+   - decodes the Base64 encoded XML payload,
+   - deserializes the `MsgHead` XML,
+   - extracts attachments from the message,
+   - removes the attachments from the `MsgHead` XML,
+   - saves the extracted attachments using Attachment Service,
+   - publishes the `MsgHead` XML without attachments to Kafka,
+   - marks the original message as read using EDI Adapter,
+   - sends an `AppRec` to NHN using EDI Adapter.
 
 ### Configuration
 
@@ -27,18 +31,27 @@ Relevant configuration for adjusting the frequency of scheduler and how many mes
 | batchSize         | Number of messages to process per batch                     | Int  |
 | scheduleInterval  | How often scheduler should poll for new messages in minutes | Int  |
 
-### Replacing ediAdapterClient with a fake
+### Local development
 
-To run this locally (meaning without actually sending any HTTP requests) change the following in App.kt:
+To run this service locally (without integration with Kafka and other services) change the following in App.kt:
 ```kotlin
-val dialogMessagePublisher = DialogMessagePublisher(deps.kafkaPublisher)
-val poller = PollerService(deps.ediAdapterClient, dialogMessagePublisher)
+val poller = PollerService(
+    deps.ediAdapterClient,
+    dialogMessagePublisher,
+    attachmentService,
+    metrics
+)
 ```
 
-to use `LocalEdiAdapterClient` and `LocalMessagePublisher` instead:
+with local implementations of the dependencies:
 ```kotlin
 val poller = PollerService(
     LocalEdiAdapterClient(),
-    LocalMessagePublisher()
+    LocalMessagePublisher(),
+    DomAttachmentService(
+        JaxbMsgHeadSerializer(),
+        LocalAttachmentClient()
+    ),
+    FakeMetrics()
 )
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.token.validation.ktor.v3)
     implementation(libs.kotlin.kafka)
     implementation(libs.edi.adapter.client)
+    implementation(libs.attachment.client)
     implementation(libs.javax.jaxb.api)
     implementation(libs.migesok.jaxb.time.adapters)
     implementation(libs.bundles.nav.xml)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ dependencyResolutionManagement {
             version("opentelemetry-extension-kotlin", "1.58.0")
             version("kotlin-kafka", "0.4.1")
             version("edi-adapter-client", "0.0.5")
+            version("attachment-client", "0.0.1")
             version("jaxb-api", "2.4.0-b180830.0359")
             version("migesok-time-adapters", "1.1.3")
 
@@ -70,6 +71,8 @@ dependencyResolutionManagement {
             library("kotlin-kafka", "io.github.nomisrev", "kotlin-kafka").versionRef("kotlin-kafka")
 
             library("edi-adapter-client", "no.nav.helsemelding", "edi-adapter-client").versionRef("edi-adapter-client")
+
+            library("attachment-client", "no.nav.helsemelding", "attachment-client").versionRef("attachment-client")
 
             library("javax-jaxb-api", "javax.xml.bind", "jaxb-api").versionRef("jaxb-api")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,7 @@ dependencyResolutionManagement {
             version("opentelemetry-extension-kotlin", "1.58.0")
             version("kotlin-kafka", "0.4.1")
             version("edi-adapter-client", "0.0.5")
-            version("attachment-client", "0.0.1")
+            version("attachment-client", "0.0.2")
             version("jaxb-api", "2.4.0-b180830.0359")
             version("migesok-time-adapters", "1.1.3")
 

--- a/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
@@ -11,6 +11,7 @@ import io.ktor.server.netty.Netty
 import io.ktor.utils.io.CancellationException
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.awaitCancellation
+import no.nav.helsemelding.attachmentclient.HttpAttachmentClient
 import no.nav.helsemelding.inbound.metrics.CustomMetrics
 import no.nav.helsemelding.inbound.plugin.configureMetrics
 import no.nav.helsemelding.inbound.plugin.configureRoutes
@@ -36,7 +37,8 @@ fun main() = SuspendApp {
 
             val dialogMessagePublisher = DialogMessagePublisher(deps.kafkaPublisher)
             val msgHeadSerializer = JaxbMsgHeadSerializer()
-            val attachmentService = DomAttachmentService(msgHeadSerializer)
+            val attachmentClient = HttpAttachmentClient()
+            val attachmentService = DomAttachmentService(msgHeadSerializer, attachmentClient)
 
             val poller = PollerService(
                 deps.ediAdapterClient,

--- a/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/App.kt
@@ -11,7 +11,6 @@ import io.ktor.server.netty.Netty
 import io.ktor.utils.io.CancellationException
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.awaitCancellation
-import no.nav.helsemelding.attachmentclient.HttpAttachmentClient
 import no.nav.helsemelding.inbound.metrics.CustomMetrics
 import no.nav.helsemelding.inbound.plugin.configureMetrics
 import no.nav.helsemelding.inbound.plugin.configureRoutes
@@ -37,8 +36,7 @@ fun main() = SuspendApp {
 
             val dialogMessagePublisher = DialogMessagePublisher(deps.kafkaPublisher)
             val msgHeadSerializer = JaxbMsgHeadSerializer()
-            val attachmentClient = HttpAttachmentClient()
-            val attachmentService = DomAttachmentService(msgHeadSerializer, attachmentClient)
+            val attachmentService = DomAttachmentService(msgHeadSerializer, deps.attachmentClient)
 
             val poller = PollerService(
                 deps.ediAdapterClient,

--- a/src/main/kotlin/no/nav/helsemelding/inbound/Dependencies.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/Dependencies.kt
@@ -7,6 +7,8 @@ import io.github.nomisRev.kafka.publisher.KafkaPublisher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.prometheus.PrometheusConfig.DEFAULT
 import io.micrometer.prometheus.PrometheusMeterRegistry
+import no.nav.helsemelding.attachmentclient.AttachmentClient
+import no.nav.helsemelding.attachmentclient.HttpAttachmentClient
 import no.nav.helsemelding.ediadapter.client.EdiAdapterClient
 import no.nav.helsemelding.ediadapter.client.HttpEdiAdapterClient
 import no.nav.helsemelding.ediadapter.client.scopedAuthHttpClient
@@ -18,7 +20,8 @@ private val log = KotlinLogging.logger {}
 data class Dependencies(
     val meterRegistry: PrometheusMeterRegistry,
     val ediAdapterClient: EdiAdapterClient,
-    val kafkaPublisher: KafkaPublisher<String, ByteArray>
+    val kafkaPublisher: KafkaPublisher<String, ByteArray>,
+    val attachmentClient: AttachmentClient
 )
 
 internal suspend fun ResourceScope.metricsRegistry(): PrometheusMeterRegistry =
@@ -37,15 +40,22 @@ suspend fun ResourceScope.dependencies(): Dependencies = awaitAll {
     val metricsRegistry = async { metricsRegistry() }
     val ediAdapterClient = async { ediAdapterClient(config.ediAdapter) }
     val kafkaPublisher = async { kafkaPublisher(config.kafka) }
+    val attachmentClient = async { attachmentClient() }
 
     Dependencies(
         metricsRegistry.await(),
         ediAdapterClient.await(),
-        kafkaPublisher.await()
+        kafkaPublisher.await(),
+        attachmentClient.await()
     )
 }
 
 internal suspend fun ResourceScope.kafkaPublisher(kafka: Kafka): KafkaPublisher<String, ByteArray> =
     install({ KafkaPublisher(kafka.toPublisherSettings()) }) { p, _ ->
         p.close().also { log.info { "Closed Kafka publisher" } }
+    }
+
+internal suspend fun ResourceScope.attachmentClient(): AttachmentClient =
+    install({ HttpAttachmentClient() }) { p, _: ExitCase ->
+        p.close().also { log.info { "Closed attachment client" } }
     }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
@@ -43,8 +43,6 @@ class DomAttachmentService(
 
     override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
         try {
-            if (attachments.isEmpty()) return true
-
             val attachmentDtoList = attachments.map {
                 AttachmentDto(
                     description = it.description,

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
@@ -42,26 +42,31 @@ class DomAttachmentService(
     }
 
     override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
-        if (attachments.isEmpty()) return true
+        try {
+            if (attachments.isEmpty()) return true
 
-        val attachmentDtoList = attachments.map {
-            AttachmentDto(
-                description = it.description,
-                contentType = it.contentType,
-                contentBase64 = it.contentBase64
-            )
-        }
+            val attachmentDtoList = attachments.map {
+                AttachmentDto(
+                    description = it.description,
+                    contentType = it.contentType,
+                    contentBase64 = it.contentBase64
+                )
+            }
 
-        val response = attachmentClient.saveAttachments(messageId, attachmentDtoList)
+            val response = attachmentClient.saveAttachments(messageId, attachmentDtoList)
 
-        if (response.isFailure) {
-            val exception = response.exceptionOrNull()
-            log.error(exception) { "Attachment test: Failed to save attachments for messageId: $messageId. Error: ${exception?.message}" }
+            if (response.isFailure) {
+                val exception = response.exceptionOrNull()
+                log.error(exception) { "Attachment test: Failed to save attachments for messageId: $messageId. Error: ${exception?.message}" }
+                return false
+            }
+
+            log.debug { "Attachment test: Saved attachments for messageId: $messageId" }
+
+            return true
+        } catch (e: Exception) {
+            log.error(e) { "Attachment test: Failed to save attachments for messageId: $messageId. Error: ${e.message}" }
             return false
         }
-
-        log.debug { "Attachment test: Saved attachments for messageId: $messageId" }
-
-        return true
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
@@ -1,5 +1,6 @@
 package no.nav.helsemelding.inbound.service
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.nav.helsemelding.attachmentclient.AttachmentClient
 import no.nav.helsemelding.inbound.model.Attachment
 import no.nav.helsemelding.inbound.model.SplitMessage
@@ -9,6 +10,8 @@ import no.nav.helsemelding.inbound.xml.removeAttachments
 import no.nav.helsemelding.inbound.xml.toAttachment
 import kotlin.uuid.Uuid
 import no.nav.helsemelding.attachmentmodel.model.Attachment as AttachmentDto
+
+private val log = KotlinLogging.logger {}
 
 interface AttachmentService {
     fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage
@@ -44,7 +47,15 @@ class DomAttachmentService(
             )
         }
 
-        attachmentClient.saveAttachments(messageId, attachmentDtos)
+        val response = attachmentClient.saveAttachments(messageId, attachmentDtos)
+
+        if (response.isFailure) {
+            val exception = response.exceptionOrNull()
+            log.error(exception) { "Attachment test: Failed to save attachments for messageId: $messageId. Error: ${exception?.message}" }
+            return false
+        }
+
+        log.debug { "Attachment test: Saved attachments for messageId: $messageId" }
 
         return true
     }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
@@ -1,17 +1,23 @@
 package no.nav.helsemelding.inbound.service
 
+import no.nav.helsemelding.attachmentclient.AttachmentClient
+import no.nav.helsemelding.inbound.model.Attachment
 import no.nav.helsemelding.inbound.model.SplitMessage
 import no.nav.helsemelding.inbound.xml.MsgHeadSerializer
 import no.nav.helsemelding.inbound.xml.extractAttachments
 import no.nav.helsemelding.inbound.xml.removeAttachments
 import no.nav.helsemelding.inbound.xml.toAttachment
+import kotlin.uuid.Uuid
+import no.nav.helsemelding.attachmentmodel.model.Attachment as AttachmentDto
 
 interface AttachmentService {
     fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage
+    suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean
 }
 
 class DomAttachmentService(
-    val msgHeadSerializer: MsgHeadSerializer
+    val msgHeadSerializer: MsgHeadSerializer,
+    val attachmentClient: AttachmentClient
 ) : AttachmentService {
     override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage {
         val msgHead = msgHeadSerializer.deserialize(msgHeadXml)
@@ -25,5 +31,21 @@ class DomAttachmentService(
             messageWithoutAttachmentXml = msgHeadSerializer.serialize(msgHead),
             attachments = attachments
         )
+    }
+
+    override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
+        if (attachments.isEmpty()) return true
+
+        val attachmentDtos = attachments.map {
+            AttachmentDto(
+                description = it.description,
+                contentType = it.contentType,
+                contentBase64 = it.contentBase64
+            )
+        }
+
+        attachmentClient.saveAttachments(messageId, attachmentDtos)
+
+        return true
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
@@ -57,15 +57,13 @@ class DomAttachmentService(
 
             if (response.isFailure) {
                 val exception = response.exceptionOrNull()
-                log.error(exception) { "Attachment test: Failed to save attachments for messageId: $messageId. Error: ${exception?.message}" }
+                log.error(exception) { "Failed to save attachments for messageId: $messageId. Error: ${exception?.message}" }
                 return false
             }
 
-            log.debug { "Attachment test: Saved attachments for messageId: $messageId" }
-
             return true
         } catch (e: Exception) {
-            log.error(e) { "Attachment test: Failed to save attachments for messageId: $messageId. Error: ${e.message}" }
+            log.error(e) { "Failed to save attachments for messageId: $messageId. Error: ${e.message}" }
             return false
         }
     }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
@@ -14,7 +14,7 @@ import no.nav.helsemelding.attachmentmodel.model.Attachment as AttachmentDto
 private val log = KotlinLogging.logger {}
 
 interface AttachmentService {
-    fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage
+    fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage?
     suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean
 }
 
@@ -22,24 +22,29 @@ class DomAttachmentService(
     val msgHeadSerializer: MsgHeadSerializer,
     val attachmentClient: AttachmentClient
 ) : AttachmentService {
-    override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage {
-        val msgHead = msgHeadSerializer.deserialize(msgHeadXml)
+    override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage? {
+        try {
+            val msgHead = msgHeadSerializer.deserialize(msgHeadXml)
 
-        val attachments = msgHead.extractAttachments()
-            .map { it.toAttachment() }
+            val attachments = msgHead.extractAttachments()
+                .map { it.toAttachment() }
 
-        msgHead.removeAttachments()
+            msgHead.removeAttachments()
 
-        return SplitMessage(
-            messageWithoutAttachmentXml = msgHeadSerializer.serialize(msgHead),
-            attachments = attachments
-        )
+            return SplitMessage(
+                messageWithoutAttachmentXml = msgHeadSerializer.serialize(msgHead),
+                attachments = attachments
+            )
+        } catch (e: Exception) {
+            log.error(e) { "Failed to split message. Error: ${e.message}" }
+            return null
+        }
     }
 
     override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
         if (attachments.isEmpty()) return true
 
-        val attachmentDtos = attachments.map {
+        val attachmentDtoList = attachments.map {
             AttachmentDto(
                 description = it.description,
                 contentType = it.contentType,
@@ -47,7 +52,7 @@ class DomAttachmentService(
             )
         }
 
-        val response = attachmentClient.saveAttachments(messageId, attachmentDtos)
+        val response = attachmentClient.saveAttachments(messageId, attachmentDtoList)
 
         if (response.isFailure) {
             val exception = response.exceptionOrNull()

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/AttachmentService.kt
@@ -14,16 +14,16 @@ import no.nav.helsemelding.attachmentmodel.model.Attachment as AttachmentDto
 private val log = KotlinLogging.logger {}
 
 interface AttachmentService {
-    fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage?
-    suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean
+    fun splitMsgHeadAndAttachments(msgHeadXml: String): Result<SplitMessage>
+    suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Result<Unit>
 }
 
 class DomAttachmentService(
     val msgHeadSerializer: MsgHeadSerializer,
     val attachmentClient: AttachmentClient
 ) : AttachmentService {
-    override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage? {
-        try {
+    override fun splitMsgHeadAndAttachments(msgHeadXml: String): Result<SplitMessage> {
+        return try {
             val msgHead = msgHeadSerializer.deserialize(msgHeadXml)
 
             val attachments = msgHead.extractAttachments()
@@ -31,18 +31,20 @@ class DomAttachmentService(
 
             msgHead.removeAttachments()
 
-            return SplitMessage(
-                messageWithoutAttachmentXml = msgHeadSerializer.serialize(msgHead),
-                attachments = attachments
+            Result.success(
+                SplitMessage(
+                    messageWithoutAttachmentXml = msgHeadSerializer.serialize(msgHead),
+                    attachments = attachments
+                )
             )
         } catch (e: Exception) {
             log.error(e) { "Failed to split message. Error: ${e.message}" }
-            return null
+            Result.failure(e)
         }
     }
 
-    override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
-        try {
+    override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Result<Unit> {
+        return try {
             val attachmentDtoList = attachments.map {
                 AttachmentDto(
                     description = it.description,
@@ -51,18 +53,15 @@ class DomAttachmentService(
                 )
             }
 
-            val response = attachmentClient.saveAttachments(messageId, attachmentDtoList)
-
-            if (response.isFailure) {
-                val exception = response.exceptionOrNull()
-                log.error(exception) { "Failed to save attachments for messageId: $messageId. Error: ${exception?.message}" }
-                return false
-            }
-
-            return true
+            attachmentClient.saveAttachments(messageId, attachmentDtoList)
+                .onFailure { exception ->
+                    log.error(exception) {
+                        "Failed to save attachments for messageId: $messageId. Error: ${exception.message}"
+                    }
+                }
         } catch (e: Exception) {
             log.error(e) { "Failed to save attachments for messageId: $messageId. Error: ${e.message}" }
-            return false
+            Result.failure(e)
         }
     }
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -105,11 +105,14 @@ class PollerService(
         val businessDocumentBase64 = getBusinessDocument(messageId) ?: return false
 
         val businessDocument = String(Base64.getDecoder().decode(businessDocumentBase64))
-        val splitMessage = attachmentService.splitMsgHeadAndAttachments(businessDocument) ?: return false
+        val splitMessage = attachmentService
+            .splitMsgHeadAndAttachments(businessDocument)
+            .getOrElse { return false }
 
         if (!splitMessage.attachments.isEmpty()) {
-            val isAttachmentsSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
-            if (!isAttachmentsSaved) return false
+            attachmentService
+                .saveAttachments(messageId, splitMessage.attachments)
+                .onFailure { return false }
         }
 
         val isPublishingSuccessful = publishMessageToKafka(messageId, splitMessage.messageWithoutAttachmentXml)

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -107,6 +107,8 @@ class PollerService(
         val payload = String(Base64.getDecoder().decode(businessDocument))
         val splitMessage = attachmentService.splitMsgHeadAndAttachments(payload)
 
+        log.debug { "Attachment test: Attachments found for message: $messageId : ${splitMessage.attachments}" }
+
         val isAttachmentSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
         if (!isAttachmentSaved) return false
 

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -107,6 +107,9 @@ class PollerService(
         val payload = String(Base64.getDecoder().decode(businessDocument))
         val splitMessage = attachmentService.splitMsgHeadAndAttachments(payload)
 
+        val isAttachmentSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
+        if (!isAttachmentSaved) return false
+
         val isPublishingSuccessful = publishMessageToKafka(messageId, splitMessage.messageWithoutAttachmentXml)
         if (!isPublishingSuccessful) return false
 

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -102,12 +102,10 @@ class PollerService(
         log.info { "Processing incoming message: $messageId" }
         metrics.registerIncomingMessageReceived()
 
-        val businessDocument = getBusinessDocument(messageId) ?: return false
+        val businessDocumentBase64 = getBusinessDocument(messageId) ?: return false
 
-        val payload = String(Base64.getDecoder().decode(businessDocument))
-        val splitMessage = attachmentService.splitMsgHeadAndAttachments(payload)
-
-        log.debug { "Attachment test: Attachments found for message: $messageId : ${splitMessage.attachments}" }
+        val businessDocument = String(Base64.getDecoder().decode(businessDocumentBase64))
+        val splitMessage = attachmentService.splitMsgHeadAndAttachments(businessDocument) ?: return false
 
         val isAttachmentSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
         if (!isAttachmentSaved) return false

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -107,8 +107,10 @@ class PollerService(
         val businessDocument = String(Base64.getDecoder().decode(businessDocumentBase64))
         val splitMessage = attachmentService.splitMsgHeadAndAttachments(businessDocument) ?: return false
 
-        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
-        if (!isAttachmentsSaved) return false
+        if (!splitMessage.attachments.isEmpty()) {
+            val isAttachmentsSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
+            if (!isAttachmentsSaved) return false
+        }
 
         val isPublishingSuccessful = publishMessageToKafka(messageId, splitMessage.messageWithoutAttachmentXml)
         if (!isPublishingSuccessful) return false

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -107,8 +107,8 @@ class PollerService(
         val businessDocument = String(Base64.getDecoder().decode(businessDocumentBase64))
         val splitMessage = attachmentService.splitMsgHeadAndAttachments(businessDocument) ?: return false
 
-        val isAttachmentSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
-        if (!isAttachmentSaved) return false
+        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, splitMessage.attachments)
+        if (!isAttachmentsSaved) return false
 
         val isPublishingSuccessful = publishMessageToKafka(messageId, splitMessage.messageWithoutAttachmentXml)
         if (!isPublishingSuccessful) return false

--- a/src/main/kotlin/no/nav/helsemelding/inbound/util/LocalAttachmentClient.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/util/LocalAttachmentClient.kt
@@ -1,0 +1,36 @@
+package no.nav.helsemelding.inbound.util
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import no.nav.helsemelding.attachmentclient.AttachmentClient
+import no.nav.helsemelding.attachmentmodel.model.Attachment
+import kotlin.uuid.Uuid
+
+private val log = KotlinLogging.logger {}
+
+class LocalAttachmentClient : AttachmentClient {
+
+    private val storedAttachments = mutableMapOf<Uuid, List<Attachment>>()
+
+    override suspend fun saveAttachments(
+        messageId: Uuid,
+        attachments: List<Attachment>
+    ): Result<Unit> {
+        log.info {
+            "LocalAttachmentClient: Saving ${attachments.size} attachment(s) for message: $messageId"
+        }
+
+        storedAttachments[messageId] = attachments
+
+        return Result.success(Unit)
+    }
+
+    override suspend fun getAttachments(
+        messageId: Uuid
+    ): Result<List<Attachment>> {
+        return Result.success(
+            storedAttachments[messageId] ?: emptyList()
+        )
+    }
+
+    override fun close() {}
+}

--- a/src/main/kotlin/no/nav/helsemelding/inbound/xml/MsgHeadExtentions.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/xml/MsgHeadExtentions.kt
@@ -4,6 +4,7 @@ import no.nav.helse.base64container.Base64Container
 import no.nav.helse.msgHead.XMLDocument
 import no.nav.helse.msgHead.XMLMsgHead
 import no.nav.helsemelding.inbound.model.Attachment
+import java.util.Base64
 
 const val ATTACHMENT_TYPE = "A"
 
@@ -57,7 +58,7 @@ fun XMLDocument.toAttachment(): Attachment =
     Attachment(
         description = refDoc.description ?: "",
         contentType = refDoc.mimeType,
-        contentBase64 = String(toBase64Container().value)
+        contentBase64 = Base64.getEncoder().encodeToString(toBase64Container().value)
     )
 
 fun XMLDocument.toBase64Container(): Base64Container =

--- a/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentClient.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentClient.kt
@@ -1,0 +1,20 @@
+package no.nav.helsemelding.inbound
+
+import no.nav.helsemelding.attachmentclient.AttachmentClient
+import no.nav.helsemelding.attachmentmodel.model.Attachment
+import kotlin.uuid.Uuid
+
+class FakeAttachmentClient : AttachmentClient {
+    override suspend fun saveAttachments(
+        messageId: Uuid,
+        attachments: List<Attachment>
+    ): Result<Unit> {
+        return Result.success(Unit)
+    }
+
+    override suspend fun getAttachments(messageId: Uuid): Result<List<Attachment>> {
+        return Result.success(emptyList())
+    }
+
+    override fun close() { }
+}

--- a/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentClient.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentClient.kt
@@ -5,11 +5,17 @@ import no.nav.helsemelding.attachmentmodel.model.Attachment
 import kotlin.uuid.Uuid
 
 class FakeAttachmentClient : AttachmentClient {
+    var saveAttachmentsResult: Result<Unit>? = null
+
+    fun givenSaveAttachmentsResult(result: Result<Unit>) {
+        saveAttachmentsResult = result
+    }
+
     override suspend fun saveAttachments(
         messageId: Uuid,
         attachments: List<Attachment>
     ): Result<Unit> {
-        return Result.success(Unit)
+        return saveAttachmentsResult!!
     }
 
     override suspend fun getAttachments(messageId: Uuid): Result<List<Attachment>> {

--- a/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
@@ -7,16 +7,21 @@ import kotlin.uuid.Uuid
 
 class FakeAttachmentService() : AttachmentService {
     private var splitMessage: SplitMessage? = null
+    private var saveAttachmentResult: Boolean = true
 
-    fun givenSplitMessage(splitMessage: SplitMessage) {
+    fun givenSplitMessage(splitMessage: SplitMessage?) {
         this.splitMessage = splitMessage
     }
 
-    override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage {
-        return splitMessage!!
+    fun givenSaveAttachmentsResult(result: Boolean) {
+        this.saveAttachmentResult = result
+    }
+
+    override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage? {
+        return splitMessage
     }
 
     override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
-        return true
+        return saveAttachmentResult
     }
 }

--- a/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
@@ -6,22 +6,25 @@ import no.nav.helsemelding.inbound.service.AttachmentService
 import kotlin.uuid.Uuid
 
 class FakeAttachmentService() : AttachmentService {
-    private var splitMessage: SplitMessage? = null
-    private var isAttachmentsSaved: Boolean = true
+    private var splitMessageResult: Result<SplitMessage> =
+        Result.failure(IllegalStateException("Split message result is not set"))
 
-    fun givenSplitMessage(splitMessage: SplitMessage?) {
-        this.splitMessage = splitMessage
+    private var saveAttachmentsResult: Result<Unit> =
+        Result.failure(IllegalStateException("Save attachments result is not set"))
+
+    fun givenSplitMessageResult(actionResult: Result<SplitMessage>) {
+        this.splitMessageResult = actionResult
     }
 
-    fun givenIsAttachmentsSaved(isSaved: Boolean) {
-        this.isAttachmentsSaved = isSaved
+    fun givenSaveAttachmentResult(actionResult: Result<Unit>) {
+        this.saveAttachmentsResult = actionResult
     }
 
-    override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage? {
-        return splitMessage
+    override fun splitMsgHeadAndAttachments(msgHeadXml: String): Result<SplitMessage> {
+        return splitMessageResult
     }
 
-    override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
-        return isAttachmentsSaved
+    override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Result<Unit> {
+        return saveAttachmentsResult
     }
 }

--- a/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
@@ -7,14 +7,14 @@ import kotlin.uuid.Uuid
 
 class FakeAttachmentService() : AttachmentService {
     private var splitMessage: SplitMessage? = null
-    private var saveAttachmentResult: Boolean = true
+    private var isAttachmentsSaved: Boolean = true
 
     fun givenSplitMessage(splitMessage: SplitMessage?) {
         this.splitMessage = splitMessage
     }
 
-    fun givenSaveAttachmentsResult(result: Boolean) {
-        this.saveAttachmentResult = result
+    fun givenIsAttachmentsSaved(isSaved: Boolean) {
+        this.isAttachmentsSaved = isSaved
     }
 
     override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage? {
@@ -22,6 +22,6 @@ class FakeAttachmentService() : AttachmentService {
     }
 
     override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
-        return saveAttachmentResult
+        return isAttachmentsSaved
     }
 }

--- a/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/FakeAttachmentService.kt
@@ -1,7 +1,9 @@
 package no.nav.helsemelding.inbound
 
+import no.nav.helsemelding.inbound.model.Attachment
 import no.nav.helsemelding.inbound.model.SplitMessage
 import no.nav.helsemelding.inbound.service.AttachmentService
+import kotlin.uuid.Uuid
 
 class FakeAttachmentService() : AttachmentService {
     private var splitMessage: SplitMessage? = null
@@ -12,5 +14,9 @@ class FakeAttachmentService() : AttachmentService {
 
     override fun splitMsgHeadAndAttachments(msgHeadXml: String): SplitMessage {
         return splitMessage!!
+    }
+
+    override suspend fun saveAttachments(messageId: Uuid, attachments: List<Attachment>): Boolean {
+        return true
     }
 }

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
@@ -54,18 +54,18 @@ class DomAttachmentServiceSpec : StringSpec({
 
         attachmentClient.givenSaveAttachmentsResult(Result.success(Unit))
 
-        val saveResult = attachmentService.saveAttachments(messageId, attachments)
+        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, attachments)
 
-        saveResult shouldBe true
+        isAttachmentsSaved shouldBe true
     }
 
     "saveAttachments should return true if there are no attachments to save" {
         val messageId = Uuid.random()
         val attachments = emptyList<Attachment>()
 
-        val saveResult = attachmentService.saveAttachments(messageId, attachments)
+        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, attachments)
 
-        saveResult shouldBe true
+        isAttachmentsSaved shouldBe true
     }
 
     "saveAttachments should return false if saving attachments fails" {
@@ -80,8 +80,8 @@ class DomAttachmentServiceSpec : StringSpec({
 
         attachmentClient.givenSaveAttachmentsResult(Result.failure(Exception("Failed to save attachments")))
 
-        val saveResult = attachmentService.saveAttachments(messageId, attachments)
+        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, attachments)
 
-        saveResult shouldBe false
+        isAttachmentsSaved shouldBe false
     }
 })

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
@@ -6,9 +6,11 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import no.nav.helsemelding.inbound.FakeAttachmentClient
+import no.nav.helsemelding.inbound.model.Attachment
 import no.nav.helsemelding.inbound.xml.JaxbMsgHeadSerializer
 import java.nio.file.Files
 import java.nio.file.Paths
+import kotlin.uuid.Uuid
 
 private val MESSAGE_WITH_ATTACHMENTS_PATH = "src/test/resources/message_with_attachments.xml"
 private val MESSAGE_WITHOUT_ATTACHMENTS_PATH = "src/test/resources/message_without_attachments.xml"
@@ -19,7 +21,7 @@ class DomAttachmentServiceSpec : StringSpec({
     val attachmentClient = FakeAttachmentClient()
     val attachmentService = DomAttachmentService(msgHeadSerializer, attachmentClient)
 
-    "should split XML message and attachments" {
+    "splitMsgHeadAndAttachments should split XML message and attachments" {
         val messageWithAttachments = String(Files.readAllBytes(Paths.get(MESSAGE_WITH_ATTACHMENTS_PATH)))
 
         val splitResult = attachmentService.splitMsgHeadAndAttachments(messageWithAttachments)
@@ -30,7 +32,7 @@ class DomAttachmentServiceSpec : StringSpec({
         splitResult.messageWithoutAttachmentXml shouldNotContain "Base64Container"
     }
 
-    "should process XML message when it does not contain attachments" {
+    "splitMsgHeadAndAttachments should process XML message when it does not contain attachments" {
         val messageWithAttachments = String(Files.readAllBytes(Paths.get(MESSAGE_WITHOUT_ATTACHMENTS_PATH)))
 
         val splitResult = attachmentService.splitMsgHeadAndAttachments(messageWithAttachments)
@@ -38,5 +40,48 @@ class DomAttachmentServiceSpec : StringSpec({
         splitResult shouldNotBe null
         splitResult!!.attachments.size shouldBe 0
         splitResult.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
+    }
+
+    "saveAttachments should return true if attachment are saved successfully" {
+        val messageId = Uuid.random()
+        val attachments = listOf(
+            Attachment(
+                description = "Test attachment",
+                contentType = "text/plain",
+                contentBase64 = "VGhpcyBpcyBhIHRlc3QgYXR0YWNobWVudC4="
+            )
+        )
+
+        attachmentClient.givenSaveAttachmentsResult(Result.success(Unit))
+
+        val saveResult = attachmentService.saveAttachments(messageId, attachments)
+
+        saveResult shouldBe true
+    }
+
+    "saveAttachments should return true if there are no attachments to save" {
+        val messageId = Uuid.random()
+        val attachments = emptyList<Attachment>()
+
+        val saveResult = attachmentService.saveAttachments(messageId, attachments)
+
+        saveResult shouldBe true
+    }
+
+    "saveAttachments should return false if saving attachments fails" {
+        val messageId = Uuid.random()
+        val attachments = listOf(
+            Attachment(
+                description = "Test attachment",
+                contentType = "text/plain",
+                contentBase64 = "VGhpcyBpcyBhIHRlc3QgYXR0YWNobWVudC4="
+            )
+        )
+
+        attachmentClient.givenSaveAttachmentsResult(Result.failure(Exception("Failed to save attachments")))
+
+        val saveResult = attachmentService.saveAttachments(messageId, attachments)
+
+        saveResult shouldBe false
     }
 })

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
@@ -28,11 +28,11 @@ class DomAttachmentServiceSpec : StringSpec({
 
         splitResult.isSuccess shouldBe true
 
-        val spritMessage = splitResult.getOrNull()
-        spritMessage shouldNotBe null
-        spritMessage!!.attachments.size shouldBe 3
-        spritMessage.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
-        spritMessage.messageWithoutAttachmentXml shouldNotContain "Base64Container"
+        val splitMessage = splitResult.getOrNull()
+        splitMessage shouldNotBe null
+        splitMessage!!.attachments.size shouldBe 3
+        splitMessage.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
+        splitMessage.messageWithoutAttachmentXml shouldNotContain "Base64Container"
     }
 
     "splitMsgHeadAndAttachments should process XML message when it does not contain attachments" {
@@ -42,10 +42,10 @@ class DomAttachmentServiceSpec : StringSpec({
 
         splitResult.isSuccess shouldBe true
 
-        val spritMessage = splitResult.getOrNull()
-        spritMessage shouldNotBe null
-        spritMessage!!.attachments.size shouldBe 0
-        spritMessage.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
+        val splitMessage = splitResult.getOrNull()
+        splitMessage shouldNotBe null
+        splitMessage!!.attachments.size shouldBe 0
+        splitMessage.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
     }
 
     "saveAttachments should return true if attachment are saved successfully" {

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
@@ -26,10 +26,13 @@ class DomAttachmentServiceSpec : StringSpec({
 
         val splitResult = attachmentService.splitMsgHeadAndAttachments(messageWithAttachments)
 
-        splitResult shouldNotBe null
-        splitResult!!.attachments.size shouldBe 3
-        splitResult.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
-        splitResult.messageWithoutAttachmentXml shouldNotContain "Base64Container"
+        splitResult.isSuccess shouldBe true
+
+        val spritMessage = splitResult.getOrNull()
+        spritMessage shouldNotBe null
+        spritMessage!!.attachments.size shouldBe 3
+        spritMessage.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
+        spritMessage.messageWithoutAttachmentXml shouldNotContain "Base64Container"
     }
 
     "splitMsgHeadAndAttachments should process XML message when it does not contain attachments" {
@@ -37,9 +40,12 @@ class DomAttachmentServiceSpec : StringSpec({
 
         val splitResult = attachmentService.splitMsgHeadAndAttachments(messageWithAttachments)
 
-        splitResult shouldNotBe null
-        splitResult!!.attachments.size shouldBe 0
-        splitResult.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
+        splitResult.isSuccess shouldBe true
+
+        val spritMessage = splitResult.getOrNull()
+        spritMessage shouldNotBe null
+        spritMessage!!.attachments.size shouldBe 0
+        spritMessage.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
     }
 
     "saveAttachments should return true if attachment are saved successfully" {
@@ -54,18 +60,18 @@ class DomAttachmentServiceSpec : StringSpec({
 
         attachmentClient.givenSaveAttachmentsResult(Result.success(Unit))
 
-        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, attachments)
+        val saveAttachmentResult = attachmentService.saveAttachments(messageId, attachments)
 
-        isAttachmentsSaved shouldBe true
+        saveAttachmentResult.isSuccess shouldBe true
     }
 
     "saveAttachments should return true if there are no attachments to save" {
         val messageId = Uuid.random()
         val attachments = emptyList<Attachment>()
 
-        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, attachments)
+        val saveAttachmentResult = attachmentService.saveAttachments(messageId, attachments)
 
-        isAttachmentsSaved shouldBe true
+        saveAttachmentResult.isSuccess shouldBe true
     }
 
     "saveAttachments should return false if saving attachments fails" {
@@ -80,8 +86,8 @@ class DomAttachmentServiceSpec : StringSpec({
 
         attachmentClient.givenSaveAttachmentsResult(Result.failure(Exception("Failed to save attachments")))
 
-        val isAttachmentsSaved = attachmentService.saveAttachments(messageId, attachments)
+        val saveAttachmentResult = attachmentService.saveAttachments(messageId, attachments)
 
-        isAttachmentsSaved shouldBe false
+        saveAttachmentResult.isSuccess shouldBe false
     }
 })

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
@@ -25,7 +25,7 @@ class DomAttachmentServiceSpec : StringSpec({
         val splitResult = attachmentService.splitMsgHeadAndAttachments(messageWithAttachments)
 
         splitResult shouldNotBe null
-        splitResult.attachments.size shouldBe 3
+        splitResult!!.attachments.size shouldBe 3
         splitResult.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
         splitResult.messageWithoutAttachmentXml shouldNotContain "Base64Container"
     }
@@ -36,7 +36,7 @@ class DomAttachmentServiceSpec : StringSpec({
         val splitResult = attachmentService.splitMsgHeadAndAttachments(messageWithAttachments)
 
         splitResult shouldNotBe null
-        splitResult.attachments.size shouldBe 0
+        splitResult!!.attachments.size shouldBe 0
         splitResult.messageWithoutAttachmentXml shouldContain "<MsgInfo>"
     }
 })

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/DomAttachmentServiceSpec.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import no.nav.helsemelding.inbound.FakeAttachmentClient
 import no.nav.helsemelding.inbound.xml.JaxbMsgHeadSerializer
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -15,7 +16,8 @@ private val MESSAGE_WITHOUT_ATTACHMENTS_PATH = "src/test/resources/message_witho
 class DomAttachmentServiceSpec : StringSpec({
 
     val msgHeadSerializer = JaxbMsgHeadSerializer()
-    val attachmentService = DomAttachmentService(msgHeadSerializer)
+    val attachmentClient = FakeAttachmentClient()
+    val attachmentService = DomAttachmentService(msgHeadSerializer, attachmentClient)
 
     "should split XML message and attachments" {
         val messageWithAttachments = String(Files.readAllBytes(Paths.get(MESSAGE_WITH_ATTACHMENTS_PATH)))

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
@@ -181,7 +181,7 @@ class PollerServiceSpec : StringSpec(
             )
 
             attachmentService.givenSplitMessage(buildSplitMessage(xml))
-            attachmentService.givenSaveAttachmentsResult(false)
+            attachmentService.givenIsAttachmentsSaved(false)
 
             val message = Message(
                 id = messageId,

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
@@ -11,6 +11,7 @@ import no.nav.helsemelding.ediadapter.model.Metadata
 import no.nav.helsemelding.inbound.FakeAttachmentService
 import no.nav.helsemelding.inbound.FakeMessagePublisher
 import no.nav.helsemelding.inbound.metrics.FakeMetrics
+import no.nav.helsemelding.inbound.model.Attachment
 import no.nav.helsemelding.inbound.model.SplitMessage
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
@@ -39,12 +40,12 @@ class PollerServiceSpec : StringSpec(
         }
 
         "Apprec should be processed" {
-            val uuid = Uuid.random()
+            val messageId = Uuid.random()
 
             ediAdapterClient.givenMarkAsRead(Right(true))
 
             val message = Message(
-                id = uuid,
+                id = messageId,
                 isAppRec = true,
                 receiverHerId = FAGSYSTEM_HER_ID
             )
@@ -53,7 +54,7 @@ class PollerServiceSpec : StringSpec(
         }
 
         "Apprec should not be processed if EDI Adapter returns error" {
-            val uuid = Uuid.random()
+            val messageId = Uuid.random()
 
             val errorMessage500 = ErrorMessage(
                 error = "Internal Server Error",
@@ -63,7 +64,7 @@ class PollerServiceSpec : StringSpec(
             ediAdapterClient.givenMarkAsRead(Left(errorMessage500))
 
             val message = Message(
-                id = uuid,
+                id = messageId,
                 isAppRec = true,
                 receiverHerId = FAGSYSTEM_HER_ID
             )
@@ -72,7 +73,7 @@ class PollerServiceSpec : StringSpec(
         }
 
         "Incoming message should be processed" {
-            val uuid = Uuid.random()
+            val messageId = Uuid.random()
 
             val xml = readFileToString("message/incomingDialogMessage.xml")
             val encoded = Base64.getEncoder().encodeToString(xml.toByteArray())
@@ -96,16 +97,12 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
+            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+
             publisher.givenPublishingResult(buildSuccessfulPublishingResult())
 
-            val splitMessage = SplitMessage(
-                messageWithoutAttachmentXml = xml,
-                attachments = emptyList()
-            )
-            attachmentService.givenSplitMessage(splitMessage)
-
             val message = Message(
-                id = uuid,
+                id = messageId,
                 isAppRec = false,
                 receiverHerId = FAGSYSTEM_HER_ID
             )
@@ -114,12 +111,12 @@ class PollerServiceSpec : StringSpec(
 
             result shouldBe true
 
-            publisher.publishedKey shouldBe uuid.toString()
+            publisher.publishedKey shouldBe messageId.toString()
             String(publisher.publishedPayload!!) shouldBe xml
         }
 
         "Incoming message should not be processed if retrieving business document fails" {
-            val uuid = Uuid.random()
+            val messageId = Uuid.random()
 
             ediAdapterClient.givenGetBusinessDocumentResponse(
                 Left(
@@ -131,10 +128,8 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
-            publisher.givenPublishingResult(buildSuccessfulPublishingResult())
-
             val message = Message(
-                id = uuid,
+                id = messageId,
                 isAppRec = false,
                 receiverHerId = FAGSYSTEM_HER_ID
             )
@@ -142,8 +137,8 @@ class PollerServiceSpec : StringSpec(
             pollerService.processMessage(message) shouldBe false
         }
 
-        "Incoming message should not be processed if publishing to Kafka fails" {
-            val uuid = Uuid.random()
+        "Incoming message should not be processed if parsing business document fails" {
+            val messageId = Uuid.random()
 
             val xml = readFileToString("message/incomingDialogMessage.xml")
             val encoded = Base64.getEncoder().encodeToString(xml.toByteArray())
@@ -158,16 +153,67 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
-            publisher.givenPublishingResult(Result.failure(RuntimeException("Kafka unavailable")))
-
-            val splitMessage = SplitMessage(
-                messageWithoutAttachmentXml = xml,
-                attachments = emptyList()
-            )
-            attachmentService.givenSplitMessage(splitMessage)
+            attachmentService.givenSplitMessage(null)
 
             val message = Message(
-                id = uuid,
+                id = messageId,
+                isAppRec = false,
+                receiverHerId = FAGSYSTEM_HER_ID
+            )
+
+            pollerService.processMessage(message) shouldBe false
+        }
+
+        "Incoming message should not be processed if saving attachments fails" {
+            val messageId = Uuid.random()
+
+            val xml = readFileToString("message/incomingDialogMessage.xml")
+            val encoded = Base64.getEncoder().encodeToString(xml.toByteArray())
+
+            ediAdapterClient.givenGetBusinessDocumentResponse(
+                Right(
+                    GetBusinessDocumentResponse(
+                        businessDocument = encoded,
+                        contentType = "application/xml",
+                        contentTransferEncoding = "base64"
+                    )
+                )
+            )
+
+            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+            attachmentService.givenSaveAttachmentsResult(false)
+
+            val message = Message(
+                id = messageId,
+                isAppRec = false,
+                receiverHerId = FAGSYSTEM_HER_ID
+            )
+
+            pollerService.processMessage(message) shouldBe false
+        }
+
+        "Incoming message should not be processed if publishing to Kafka fails" {
+            val messageId = Uuid.random()
+
+            val xml = readFileToString("message/incomingDialogMessage.xml")
+            val encoded = Base64.getEncoder().encodeToString(xml.toByteArray())
+
+            ediAdapterClient.givenGetBusinessDocumentResponse(
+                Right(
+                    GetBusinessDocumentResponse(
+                        businessDocument = encoded,
+                        contentType = "application/xml",
+                        contentTransferEncoding = "base64"
+                    )
+                )
+            )
+
+            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+
+            publisher.givenPublishingResult(Result.failure(RuntimeException("Kafka unavailable")))
+
+            val message = Message(
+                id = messageId,
                 isAppRec = false,
                 receiverHerId = FAGSYSTEM_HER_ID
             )
@@ -176,7 +222,7 @@ class PollerServiceSpec : StringSpec(
         }
 
         "Incoming message should not be processed if marking as read fails" {
-            val uuid = Uuid.random()
+            val messageId = Uuid.random()
 
             val xml = readFileToString("message/incomingDialogMessage.xml")
             val encoded = Base64.getEncoder().encodeToString(xml.toByteArray())
@@ -198,16 +244,12 @@ class PollerServiceSpec : StringSpec(
             )
             ediAdapterClient.givenMarkAsRead(Left(errorMessage500))
 
+            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+
             publisher.givenPublishingResult(buildSuccessfulPublishingResult())
 
-            val splitMessage = SplitMessage(
-                messageWithoutAttachmentXml = xml,
-                attachments = emptyList()
-            )
-            attachmentService.givenSplitMessage(splitMessage)
-
             val message = Message(
-                id = uuid,
+                id = messageId,
                 isAppRec = false,
                 receiverHerId = FAGSYSTEM_HER_ID
             )
@@ -216,7 +258,7 @@ class PollerServiceSpec : StringSpec(
         }
 
         "Incoming message should not be processed if sending apprec fails" {
-            val uuid = Uuid.random()
+            val messageId = Uuid.random()
 
             val xml = readFileToString("message/incomingDialogMessage.xml")
             val encoded = Base64.getEncoder().encodeToString(xml.toByteArray())
@@ -241,16 +283,12 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
+            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+
             publisher.givenPublishingResult(buildSuccessfulPublishingResult())
 
-            val splitMessage = SplitMessage(
-                messageWithoutAttachmentXml = xml,
-                attachments = emptyList()
-            )
-            attachmentService.givenSplitMessage(splitMessage)
-
             val message = Message(
-                id = uuid,
+                id = messageId,
                 isAppRec = false,
                 receiverHerId = FAGSYSTEM_HER_ID
             )
@@ -274,6 +312,17 @@ fun buildSuccessfulPublishingResult(): Result<RecordMetadata> {
     )
     return Result.success(record)
 }
+
+fun buildSplitMessage(xml: String) = SplitMessage(
+    messageWithoutAttachmentXml = xml,
+    attachments = listOf(
+        Attachment(
+            description = "Test attachment",
+            contentType = "application/pdf",
+            contentBase64 = "VGhpcyBpcyBhIHRlc3QgYXR0YWNobWVudA=="
+        )
+    )
+)
 
 fun readFileToString(path: String): String {
     return PollerServiceSpec::class.java.classLoader.getResource(path)!!.readText()

--- a/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
+++ b/src/test/kotlin/no/nav/helsemelding/inbound/service/PollerServiceSpec.kt
@@ -97,7 +97,12 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
-            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+            attachmentService.givenSplitMessageResult(
+                Result.success(buildSplitMessage(xml))
+            )
+            attachmentService.givenSaveAttachmentResult(
+                Result.success(Unit)
+            )
 
             publisher.givenPublishingResult(buildSuccessfulPublishingResult())
 
@@ -153,7 +158,9 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
-            attachmentService.givenSplitMessage(null)
+            attachmentService.givenSplitMessageResult(
+                Result.failure(RuntimeException("Parsing failed"))
+            )
 
             val message = Message(
                 id = messageId,
@@ -180,8 +187,12 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
-            attachmentService.givenSplitMessage(buildSplitMessage(xml))
-            attachmentService.givenIsAttachmentsSaved(false)
+            attachmentService.givenSplitMessageResult(
+                Result.success(buildSplitMessage(xml))
+            )
+            attachmentService.givenSplitMessageResult(
+                Result.failure(RuntimeException("Saving attachments failed"))
+            )
 
             val message = Message(
                 id = messageId,
@@ -208,7 +219,12 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
-            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+            attachmentService.givenSplitMessageResult(
+                Result.success(buildSplitMessage(xml))
+            )
+            attachmentService.givenSaveAttachmentResult(
+                Result.success(Unit)
+            )
 
             publisher.givenPublishingResult(Result.failure(RuntimeException("Kafka unavailable")))
 
@@ -244,7 +260,12 @@ class PollerServiceSpec : StringSpec(
             )
             ediAdapterClient.givenMarkAsRead(Left(errorMessage500))
 
-            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+            attachmentService.givenSplitMessageResult(
+                Result.success(buildSplitMessage(xml))
+            )
+            attachmentService.givenSaveAttachmentResult(
+                Result.success(Unit)
+            )
 
             publisher.givenPublishingResult(buildSuccessfulPublishingResult())
 
@@ -283,7 +304,12 @@ class PollerServiceSpec : StringSpec(
                 )
             )
 
-            attachmentService.givenSplitMessage(buildSplitMessage(xml))
+            attachmentService.givenSplitMessageResult(
+                Result.success(buildSplitMessage(xml))
+            )
+            attachmentService.givenSaveAttachmentResult(
+                Result.success(Unit)
+            )
 
             publisher.givenPublishingResult(buildSuccessfulPublishingResult())
 


### PR DESCRIPTION
1. Utført integrasjon med `helsemelding-attachment-service`.
2. Utført lagring av vedlegg før en melding blir sendt til Kafka.
3. Utvidet tester.
4. Oppdatert `README`

Oppgave: https://github.com/navikt/helsemelding-inbound-message-service/issues/15