### PR TITLE
#13 Metrikker for vedlegg

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/inbound/metrics/ErrorTypeTag.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/metrics/ErrorTypeTag.kt
@@ -4,5 +4,7 @@ enum class ErrorTypeTag(val value: String) {
     RETRIEVING_BUSINESS_DOCUMENT_FAILED("retrieving_business_document_failed"),
     PUBLISHING_TO_KAFKA_FAILED("publishing_to_kafka_failed"),
     MARKING_MESSAGE_AS_READ_FAILED("marking_message_as_read_failed"),
-    SENDING_APPREC_FAILED("sending_apprec_failed")
+    SENDING_APPREC_FAILED("sending_apprec_failed"),
+    SPLITTING_MESSAGE_FAILED("splitting_message_failed"),
+    SAVING_ATTACHMENTS_FAILED("saving_attachments_failed")
 }

--- a/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/inbound/service/PollerService.kt
@@ -107,12 +107,18 @@ class PollerService(
         val businessDocument = String(Base64.getDecoder().decode(businessDocumentBase64))
         val splitMessage = attachmentService
             .splitMsgHeadAndAttachments(businessDocument)
-            .getOrElse { return false }
+            .getOrElse {
+                metrics.registerIncomingMessageFailed(ErrorTypeTag.SPLITTING_MESSAGE_FAILED)
+                return false
+            }
 
         if (!splitMessage.attachments.isEmpty()) {
             attachmentService
                 .saveAttachments(messageId, splitMessage.attachments)
-                .onFailure { return false }
+                .onFailure {
+                    metrics.registerIncomingMessageFailed(ErrorTypeTag.SAVING_ATTACHMENTS_FAILED)
+                    return false
+                }
         }
 
         val isPublishingSuccessful = publishMessageToKafka(messageId, splitMessage.messageWithoutAttachmentXml)


### PR DESCRIPTION
Utført registrering av `helsemelding_incoming_messages_failed` metrikken når:
- oppdeling av XML meldingen er mislykket.
- lagring av vedlegget er mislykket.

Oppgave: https://github.com/navikt/helsemelding-attachment-service/issues/13